### PR TITLE
FIX : lorsqu'on groupe les lignes en utilisant la référence du produi…

### DIFF
--- a/class/actions_declinaison.class.php
+++ b/class/actions_declinaison.class.php
@@ -62,12 +62,13 @@ class ActionsDeclinaison
 							$object->lines[$line_k]->total_ht+=$line->total_ht;
 							$object->lines[$line_k]->total+=$line->total;
 							$object->lines[$k]->special_code = 3;
+							$object->lines[$line_k]->desc = $object->lines[$line_k]->description = ''; // Sinon utilise la description de la ligne dans laquelle on groupe les qtés, donc celle d'une déclinaison.
 							//unset($object->lines[$k]);
 							//var_dump($fk_product,$line_k,$k,$object->lines[$line_k]->qty);exit;
 						}
 
 					}
-
+					
 					ksort($object->lines);
 
 				}


### PR DESCRIPTION
…t parent, on vide la description sinon dans certains cas garde celle de la première déclinaison trouvée, ce qui n'a plus de sens